### PR TITLE
時間計算量を改善

### DIFF
--- a/lib/formatter.ts
+++ b/lib/formatter.ts
@@ -24,14 +24,11 @@ export function format(fileName: string, text: string, options = createDefaultFo
 
     const languageService = ts.createLanguageService(host);
     const edits = languageService.getFormattingEditsForDocument(fileName, options);
-    edits
+    const [lastEnd, result] = edits
         .sort((a, b) => a.span.start - b.span.start)
-        .reverse()
-        .forEach(edit => {
-            const head = text.slice(0, edit.span.start);
-            const tail = text.slice(edit.span.start + edit.span.length);
-            text = `${head}${edit.newText}${tail}`;
-        });
-
-    return text;
+        .reduce<[number, string]>(
+            ([lastEnd, result], edit) =>
+                [edit.span.start + edit.span.length, result + text.slice(lastEnd, edit.span.start) + edit.newText],
+            [0, ""]);
+    return result + text.slice(lastEnd);
 }


### PR DESCRIPTION
format()関数のeditsを適用する計算量が、およそO(ソース文字列.length × edits.length)になっていたので、O(ソース文字列.length + edits.length * log(edits.length)) になるように変更しました。